### PR TITLE
Exclude floating windows from the list of candidates

### DIFF
--- a/lua/window-picker.lua
+++ b/lua/window-picker.lua
@@ -67,6 +67,9 @@ local function choose(hl)
     if exclude[api.nvim_buf_get_option(bufnr, 'filetype')] == true then
       return false
     end
+    if api.nvim_win_get_config(id).relative ~= '' then
+      return false
+    end
 
     return true
   end, win_ids)


### PR DESCRIPTION
I use lots of plugins that utilize floating windows to display contexts, hovers so I added a check to skip those windows. Besides floating windows don't support statusline, so I think it is reasonable.