### PR TITLE
Use ':hi-default' to set the highlights

### DIFF
--- a/lua/window-picker.lua
+++ b/lua/window-picker.lua
@@ -191,7 +191,7 @@ function M.swap(stay, winid)
   flash_highlight(winid, M.config.flash_duration, 'WindowPickerSwap')
 end
 
-vim.cmd 'hi WindowPicker     guifg=#ededed guibg=#5e81ac gui=bold'
-vim.cmd 'hi WindowPickerSwap guifg=#ededed guibg=#d08770 gui=bold'
+vim.cmd 'hi default WindowPicker     guifg=#ededed guibg=#5e81ac gui=bold'
+vim.cmd 'hi default WindowPickerSwap guifg=#ededed guibg=#d08770 gui=bold'
 
 return M


### PR DESCRIPTION
Sorry for yet another small fix. I'm also a Nord fellow and used the default highlights until now so didn't notice this for so long.

With the current command, if the user sets the colorscheme before loading `window-picker.nvim`, their settings will be overwritten. Applying `default` to the commands ensures the custom colors defined by the user are always honored.